### PR TITLE
Improve Extension Sign-In

### DIFF
--- a/src/lib/components/Login.svelte
+++ b/src/lib/components/Login.svelte
@@ -28,14 +28,16 @@
     src={pfp}
     alt={username}
   />
-  <Popover
-    class='popover-leather w-fit'
-    placement='bottom'
-    target='avatar'
-  >
-    <h3 class='text-lg font-bold'>{username}</h3>
-    <h4 class='text-base'>@{tag}</h4>
-</Popover>
+  {#key username || tag}
+    <Popover
+      class='popover-leather w-fit'
+      placement='bottom'
+      target='avatar'
+    >
+      <h3 class='text-lg font-bold'>{username}</h3>
+      <h4 class='text-base'>@{tag}</h4>
+    </Popover>
+  {/key}
 {:else}
   <Avatar rounded class='h-6 w-6 m-4 cursor-pointer' id='avatar' />
   <Popover

--- a/src/lib/components/Login.svelte
+++ b/src/lib/components/Login.svelte
@@ -1,35 +1,24 @@
 <script lang='ts'>
   import { Avatar, Button, Popover } from 'flowbite-svelte';
-  import { NDKNip07Signer, type NDKUserProfile } from '@nostr-dev-kit/ndk';
-  import { ndkInstance, ndkSignedIn } from '$lib/ndk';
+  import { type NDKUserProfile } from '@nostr-dev-kit/ndk';
+  import { ndkSignedIn, signInWithExtension } from '$lib/ndk';
 
   let profile = $state<NDKUserProfile | null>(null);
   let pfp = $derived(profile?.image);
   let username = $derived(profile?.name);
   let tag = $derived(profile?.name);
 
-  const signInWithExtension = async () => {
-    const signer = new NDKNip07Signer();
-    const user = await signer.user();
-    
-    // Michael J 01/03/2025 - This updates the shared NDK instance in its store, which is global
-    // in scope.  Since this app is not server-side rendered, this is safe.  If we implement
-    // server-side rendering, we should migrate this shared state to Svelte's context API.
-    user.ndk = $ndkInstance;
-    $ndkInstance.signer = signer;
-    $ndkInstance.activeUser = user;
+  let signInFailed = $state<boolean>(false);
 
-    await $ndkInstance.connect();
-    profile = await $ndkInstance.activeUser?.fetchProfile();
-
-    console.debug('NDK signed in with extension and reconnected.');
-
-    $ndkSignedIn = true;
-  };
-
-  const signInWithBunker = () => {
-    console.warn('Bunker sign-in not yet implemented.');
-  };
+  async function handleSignInClick() {
+    try {
+      profile = await signInWithExtension();
+    } catch (e) {
+      console.error(e);
+      signInFailed = true;
+      // TODO: Show an error message to the user.
+    }
+  }
 </script>
 
 {#if $ndkSignedIn}
@@ -56,7 +45,7 @@
   >
     <div class='w-full flex space-x-2'>
       <Button
-        on:click={signInWithExtension}
+        onclick={handleSignInClick}
       >
         Extension Sign-In
       </Button>

--- a/src/lib/components/PublicationFeed.svelte
+++ b/src/lib/components/PublicationFeed.svelte
@@ -1,0 +1,115 @@
+<script lang='ts'>
+  import { indexKind } from '$lib/consts';
+  import { ndkInstance } from '$lib/ndk';
+  import { filterValidIndexEvents } from '$lib/utils';
+  import { NDKRelaySet, type NDKEvent } from '@nostr-dev-kit/ndk';
+  import { Button, P, Skeleton, Spinner } from 'flowbite-svelte';
+  import ArticleHeader from './ArticleHeader.svelte';
+  import { onMount } from 'svelte';
+
+  let { relays } = $props<{ relays: string[] }>();
+
+  let eventsInView: NDKEvent[] = $state([]);
+  let loadingMore: boolean = $state(false);
+  let endOfFeed: boolean = $state(false);
+
+  let cutoffTimestamp: number = $derived(
+    eventsInView?.at(eventsInView.length - 1)?.created_at ?? new Date().getTime()
+  );
+
+  async function getEvents(
+    before: number | undefined = undefined,
+  ): Promise<void> {
+    let eventSet = await $ndkInstance.fetchEvents(
+      { 
+        kinds: [indexKind],
+        limit: 16,
+        until: before,
+      },
+      { 
+        groupable: true,
+        skipVerification: false,
+        skipValidation: false
+      },
+      NDKRelaySet.fromRelayUrls(relays, $ndkInstance)
+    );
+    eventSet = filterValidIndexEvents(eventSet);
+    
+    let eventArray = Array.from(eventSet);
+    eventArray?.sort((a, b) => b.created_at! - a.created_at!);
+
+    if (!eventArray) {
+      return;
+    }
+
+    endOfFeed = eventArray?.at(eventArray.length - 1)?.id === eventsInView?.at(eventsInView.length - 1)?.id;
+
+    if (endOfFeed) {
+      return;
+    }
+
+    const eventMap = new Map([...eventsInView, ...eventArray].map(event => [event.id, event]));
+    const allEvents = Array.from(eventMap.values());
+    const uniqueIds = new Set(allEvents.map(event => event.id));
+    eventsInView = Array.from(uniqueIds)
+      .map(id => eventMap.get(id))
+      .filter(event => event != null) as NDKEvent[];
+  }
+
+  const getSkeletonIds = (): string[] => {
+    const skeletonHeight = 124; // The height of the skeleton component in pixels.
+
+    // Determine the number of skeletons to display based on the height of the screen.
+    const skeletonCount = Math.floor(window.innerHeight / skeletonHeight) - 2;
+
+    const skeletonIds = [];
+    for (let i = 0; i < skeletonCount; i++) {
+      skeletonIds.push(`skeleton-${i}`);
+    }
+    return skeletonIds;
+  }
+
+  async function loadMorePublications() {
+    loadingMore = true;
+    await getEvents(cutoffTimestamp);
+    loadingMore = false;
+  }
+
+  onMount(async () => {
+    await getEvents();
+  });
+</script>
+
+<div class='leather flex flex-col flex-grow-0 space-y-4 overflow-y-auto w-max p-2'>
+  {#if eventsInView.length === 0}
+    {#each getSkeletonIds() as id}
+      <Skeleton size='lg' />
+    {/each}
+  {:else if eventsInView.length > 0}
+    {#each eventsInView as event}
+      <ArticleHeader {event} />
+    {/each}
+  {:else}
+    <p class='text-center'>No articles found.</p>
+  {/if}
+  {#if !loadingMore && !endOfFeed}
+    <div class='flex justify-center mt-4 mb-8'>
+      <Button outline class="w-full" onclick={async () => {
+        await loadMorePublications();
+      }}>
+        Show more publications
+      </Button>
+    </div>
+  {:else if loadingMore}
+    <div class='flex justify-center mt-4 mb-8'>
+      <Button outline disabled class="w-full">
+        <Spinner class='mr-3 text-gray-300' size='4' />
+        Loading...
+      </Button>
+    </div>
+  {:else}
+    <div class='flex justify-center mt-4 mb-8'>
+      <P class='text-sm text-gray-600'>You've reached the end of the feed.</P>
+    </div>
+  {/if}
+</div>

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -4,6 +4,6 @@ export const zettelKinds = [ 30041 ];
 export const standardRelays = [ "wss://thecitadel.nostr1.com", "wss://relay.noswhere.com" ];
 
 export enum FeedType {
-  Relays,
-  Follows,
+  StandardRelays,
+  UserRelays,
 }

--- a/src/lib/ndk.ts
+++ b/src/lib/ndk.ts
@@ -5,8 +5,8 @@ export const ndkInstance: Writable<NDK> = writable();
 
 export const ndkSignedIn: Writable<boolean> = writable(false);
 
-export const inboxRelays: Writable<Set<NDKRelay>> = writable(new Set());
-export const outboxRelays: Writable<Set<NDKRelay>> = writable(new Set());
+export const inboxRelays: Writable<string[]> = writable([]);
+export const outboxRelays: Writable<string[]> = writable([]);
 
 /**
  * Signs in with a NIP-07 browser extension, and determines the user's preferred inbox and outbox
@@ -24,8 +24,8 @@ export async function signInWithExtension(): Promise<NDKUserProfile | null> {
     const user = ndk.getUser({ pubkey: signerUser.pubkey });
     const [inboxes, outboxes] = await getUserPreferredRelays(ndk, user);
 
-    inboxRelays.set(inboxes);
-    outboxRelays.set(outboxes);
+    inboxRelays.set(Array.from(inboxes).map(relay => relay.url));
+    outboxRelays.set(Array.from(outboxes).map(relay => relay.url));
 
     ndk.signer = signer;
     ndk.activeUser = user;

--- a/src/lib/ndk.ts
+++ b/src/lib/ndk.ts
@@ -33,7 +33,7 @@ export async function signInWithExtension(): Promise<NDKUserProfile | null> {
     ndkSignedIn.set(true);
     ndkInstance.set(ndk);
 
-    return user.profile ?? null;
+    return user.fetchProfile();
   } catch (e) {
     throw new Error(`Failed to sign in with NIP-07 extension: ${e}`);
   }

--- a/src/lib/ndk.ts
+++ b/src/lib/ndk.ts
@@ -1,6 +1,81 @@
-import NDK from '@nostr-dev-kit/ndk';
-import { writable, type Writable } from 'svelte/store';
+import NDK, { NDKNip07Signer, NDKRelay, NDKUser, type NDKUserProfile } from '@nostr-dev-kit/ndk';
+import { get, writable, type Writable } from 'svelte/store';
 
 export const ndkInstance: Writable<NDK> = writable();
 
 export const ndkSignedIn: Writable<boolean> = writable(false);
+
+export const inboxRelays: Writable<Set<NDKRelay>> = writable(new Set());
+export const outboxRelays: Writable<Set<NDKRelay>> = writable(new Set());
+
+/**
+ * Signs in with a NIP-07 browser extension, and determines the user's preferred inbox and outbox
+ * relays.
+ * @returns The user's profile, if it is available.
+ * @throws If sign-in fails.  This may because there is no accessible NIP-07 extension, or because
+ * NDK is unable to fetch the user's profile or relay lists.
+ */
+export async function signInWithExtension(): Promise<NDKUserProfile | null> {
+  try {
+    const ndk = get(ndkInstance);
+    const signer = new NDKNip07Signer();
+    const signerUser = await signer.user();
+
+    const user = ndk.getUser({ pubkey: signerUser.pubkey });
+    const [inboxes, outboxes] = await getUserPreferredRelays(ndk, user);
+
+    inboxRelays.set(inboxes);
+    outboxRelays.set(outboxes);
+
+    ndk.signer = signer;
+    ndk.activeUser = user;
+
+    ndkSignedIn.set(true);
+    ndkInstance.set(ndk);
+
+    return user.profile ?? null;
+  } catch (e) {
+    throw new Error(`Failed to sign in with NIP-07 extension: ${e}`);
+  }
+}
+
+/**
+ * Fetches the user's NIP-65 relay list, if one can be found, and returns the inbox and outbox
+ * relay sets.
+ * @returns A tuple of relay sets of the form `[inboxRelays, outboxRelays]`.
+ */
+async function getUserPreferredRelays(
+  ndk: NDK,
+  user: NDKUser
+): Promise<[Set<NDKRelay>, Set<NDKRelay>]> {
+  const relayLists = await ndk.fetchEvents({
+    kinds: [10002],
+    authors: [user.pubkey],
+  });
+
+  if (relayLists.size === 0) {
+    throw new Error(`No relay lists found for the given user: ${user.pubkey}`);
+  }
+
+  const inboxRelays = new Set<NDKRelay>();
+  const outboxRelays = new Set<NDKRelay>();
+
+  relayLists.forEach(relayList => {
+    relayList.tags.forEach(tag => {
+      switch (tag[0]) {
+        case 'r':
+          inboxRelays.add(new NDKRelay(tag[1]));
+          break;
+        case 'w':
+          outboxRelays.add(new NDKRelay(tag[1]));
+          break;
+        default:
+          inboxRelays.add(new NDKRelay(tag[1]));
+          outboxRelays.add(new NDKRelay(tag[1]));
+          break;
+      }
+    });
+  });
+
+  return [inboxRelays, outboxRelays];
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,66 +1,11 @@
 <script lang='ts'>
-  import ArticleHeader from '$lib/components/ArticleHeader.svelte';
-  import { FeedType, indexKind, standardRelays } from '$lib/consts';
-  import { filterValidIndexEvents } from '$lib/utils';
-  import { NDKEvent, NDKRelaySet, type NDKUser } from '@nostr-dev-kit/ndk';
-  import { Button, Dropdown, P, Radio, Skeleton, Spinner } from 'flowbite-svelte';
+  import { FeedType, standardRelays } from '$lib/consts';
+  import { Button, Dropdown, Radio } from 'flowbite-svelte';
   import { ChevronDownOutline } from 'flowbite-svelte-icons';
   import { inboxRelays, ndkInstance, ndkSignedIn } from '$lib/ndk';
+  import PublicationFeed from '$lib/components/PublicationFeed.svelte';
 
-  let user: NDKUser | null | undefined = $state($ndkInstance.activeUser);
   let feedType: FeedType = $state(FeedType.StandardRelays);
-  let eventsInView: NDKEvent[] = $state([]);
-  let loadingMore: boolean = $state(false);
-  let endOfFeed: boolean = $state(false);
-
-  let cutoffTimestamp: number = $derived(
-    eventsInView?.at(eventsInView.length - 1)?.created_at ?? new Date().getTime()
-  );
-
-  async function getEvents(
-    before: number | undefined = undefined,
-    relays: string[] = standardRelays
-  ): Promise<void> {
-    let eventSet = await $ndkInstance.fetchEvents(
-      { 
-        kinds: [indexKind],
-        limit: 16,
-        until: before,
-      },
-      { 
-        groupable: true,
-        skipVerification: false,
-        skipValidation: false
-      },
-      NDKRelaySet.fromRelayUrls(relays, $ndkInstance)
-    );
-    eventSet = filterValidIndexEvents(eventSet);
-    
-    let eventArray = Array.from(eventSet);
-    eventArray?.sort((a, b) => b.created_at! - a.created_at!);
-
-    if (!eventArray) {
-      return;
-    }
-
-    endOfFeed = eventArray?.at(eventArray.length - 1)?.id === eventsInView?.at(eventsInView.length - 1)?.id;
-
-    if (endOfFeed) {
-      return;
-    }
-
-    const eventMap = new Map([...eventsInView, ...eventArray].map(event => [event.id, event]));
-    const allEvents = Array.from(eventMap.values());
-    const uniqueIds = new Set(allEvents.map(event => event.id));
-    eventsInView = Array.from(uniqueIds)
-      .map(id => eventMap.get(id))
-      .filter(event => event != null) as NDKEvent[];
-  }
-
-  // TODO: Use the user's inbox relays.
-  async function getEventsFromUserRelays(before: number = cutoffTimestamp): Promise<void> {
-    await getEvents(before, $inboxRelays);
-  }
 
   // TODO: Remove feed type switching.  We will use relays only for now.
   const getFeedTypeFriendlyName = (feedType: FeedType): string => {
@@ -73,46 +18,11 @@
       return '';
     }
   };
-
-  const getSkeletonIds = (): string[] => {
-    const skeletonHeight = 124; // The height of the skeleton component in pixels.
-
-    // Determine the number of skeletons to display based on the height of the screen.
-    const skeletonCount = Math.floor(window.innerHeight / skeletonHeight) - 2;
-
-    const skeletonIds = [];
-    for (let i = 0; i < skeletonCount; i++) {
-      skeletonIds.push(`skeleton-${i}`);
-    }
-    return skeletonIds;
-  }
-
-  async function loadMorePublications() {
-    loadingMore = true;
-    if (user != null) {
-      await getEventsFromUserRelays(cutoffTimestamp);
-    } else {
-      await getEvents(cutoffTimestamp);
-    }
-    loadingMore = false;
-  }
 </script>
 
 <div class='leather flex flex-col flex-grow-0 space-y-4 overflow-y-auto w-max p-2'>
   {#if !$ndkSignedIn}
-    {#await getEvents()}
-      {#each getSkeletonIds() as id}
-        <Skeleton size='lg' />
-      {/each}
-    {:then}
-      {#if eventsInView.length > 0}
-        {#each eventsInView as event}
-          <ArticleHeader {event} />
-        {/each}
-      {:else}
-        <p class='text-center'>No articles found.</p>
-      {/if}
-    {/await}
+    <PublicationFeed relays={standardRelays} />
   {:else}
     <div class='leather w-full flex justify-end'>
       <Button>
@@ -128,53 +38,9 @@
       </Dropdown>
     </div>
     {#if feedType === FeedType.StandardRelays}
-      {#await getEvents()}
-        {#each getSkeletonIds() as id}
-          <Skeleton size='lg' />
-        {/each}
-      {:then}
-        {#if eventsInView.length > 0}
-          {#each eventsInView as event}
-            <ArticleHeader {event} />
-          {/each}
-        {:else}
-          <p class='text-center'>No articles found.</p>
-        {/if}
-      {/await}
+      <PublicationFeed relays={standardRelays} />
     {:else if feedType === FeedType.UserRelays}
-      {#await getEventsFromUserRelays()}
-        {#each getSkeletonIds() as id}
-          <Skeleton size='lg' />
-        {/each}
-      {:then}
-        {#if eventsInView.length > 0}
-          {#each eventsInView as event}
-            <ArticleHeader {event} />
-          {/each}
-        {:else}
-          <p class='text-center'>No articles found.</p>
-        {/if}
-      {/await}
+      <PublicationFeed relays={$inboxRelays} />
     {/if}
-  {/if}
-  {#if !loadingMore && !endOfFeed}
-    <div class='flex justify-center mt-4 mb-8'>
-      <Button outline class="w-full" onclick={async () => {
-        await loadMorePublications();
-      }}>
-        Show more publications
-      </Button>
-    </div>
-  {:else if loadingMore}
-    <div class='flex justify-center mt-4 mb-8'>
-      <Button outline disabled class="w-full">
-        <Spinner class='mr-3 text-gray-300' size='4' />
-        Loading...
-      </Button>
-    </div>
-  {:else}
-    <div class='flex justify-center mt-4 mb-8'>
-      <P class='text-sm text-gray-600'>You've reached the end of the feed.</P>
-    </div>
   {/if}
 </div>


### PR DESCRIPTION
PR for [ALEX-29: Login with browser extension](https://shadowysupercoding.atlassian.net/browse/ALEX-29?atlOrigin=eyJpIjoiNDFiNTJlOGI4MzA2NDM3ZDhjNDAzYWUyNjdhMmFkOWMiLCJwIjoiaiJ9)

Extension sign-in is properly handled, and the home feed view is reconfigured based on the user's profile.

## Changelog

- User sign-in behavior is more fully defined.
    - The user's profile picture and display name are shown in the login component.
    - Inbox and outbox relays are fetched from the user's NIP-65 preferred relay list event and saved to Svelte stores.
- The home page feed behavior is revamped.
    - The number of publications initially loaded to the feed is limited.
    - A "show more" button is added that causes additional publications to be fetched.
    - Upon sign-in, the feed is refreshed with publications from the user's inbox relays.
    - After sign-in, the user may choose between viewing publications from the default Alexandria relays or from the user's relay list.

## Notes for Reviewer

Depends on #8.  Review and merge that PR first to reduce the diff in this one.