### PR TITLE
Miscellaneous Bugfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "alexandria",
       "version": "0.0.6",
       "dependencies": {
-        "@nostr-dev-kit/ndk": "2.10.x",
+        "@nostr-dev-kit/ndk": "2.11.x",
         "@nostr-dev-kit/ndk-cache-dexie": "2.5.x",
         "@popperjs/core": "2.11.x",
         "@tailwindcss/forms": "0.5.x",
@@ -1023,9 +1023,9 @@
       }
     },
     "node_modules/@nostr-dev-kit/ndk": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/@nostr-dev-kit/ndk/-/ndk-2.10.7.tgz",
-      "integrity": "sha512-cylva8jsaAGMijxAI32CnJWlzvwD4sWyl86/+RMS6xpZn4MIgeVUfBFc/pYkcfZzDP3v1Z9mIPsuiICRyvu9yQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@nostr-dev-kit/ndk/-/ndk-2.11.0.tgz",
+      "integrity": "sha512-FKIMtcVsVcquzrC+yir9lOXHCIHmQ3IKEVCMohqEB7N96HjP2qrI9s5utbjI3lkavFNF5tXg1Gp9ODEo7XCfLA==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.6.0",
@@ -1055,6 +1055,28 @@
         "dexie": "^4.0.8",
         "nostr-tools": "^2.4.0",
         "typescript-lru-cache": "^2.0.0"
+      }
+    },
+    "node_modules/@nostr-dev-kit/ndk-cache-dexie/node_modules/@nostr-dev-kit/ndk": {
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@nostr-dev-kit/ndk/-/ndk-2.10.7.tgz",
+      "integrity": "sha512-cylva8jsaAGMijxAI32CnJWlzvwD4sWyl86/+RMS6xpZn4MIgeVUfBFc/pYkcfZzDP3v1Z9mIPsuiICRyvu9yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@noble/secp256k1": "^2.1.0",
+        "@scure/base": "^1.1.9",
+        "debug": "^4.3.6",
+        "light-bolt11-decoder": "^3.2.0",
+        "nostr-tools": "^2.7.1",
+        "tseep": "^1.2.2",
+        "typescript-lru-cache": "^2.0.0",
+        "utf8-buffer": "^1.0.0",
+        "websocket-polyfill": "^0.0.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --plugin-search-dir . --write ."
   },
   "dependencies": {
-    "@nostr-dev-kit/ndk": "2.10.x",
+    "@nostr-dev-kit/ndk": "2.11.x",
     "@nostr-dev-kit/ndk-cache-dexie": "2.5.x",
     "@popperjs/core": "2.11.x",
     "@tailwindcss/forms": "0.5.x",

--- a/src/lib/components/ArticleHeader.svelte
+++ b/src/lib/components/ArticleHeader.svelte
@@ -80,7 +80,7 @@
         {/if}
       </a>
       <div class='w-full flex space-x-2 justify-end'>
-        <Button class='btn-leather' size='xs' on:click={shareNjump}><ShareNodesOutline /></Button>
+        <Button class='btn-leather' size='xs' onclick={shareNjump}><ShareNodesOutline /></Button>
         <Tooltip class='tooltip-leather' type='auto' placement='top' on:show={() => shareLinkCopied = false}>
           {#if shareLinkCopied}
             <ClipboardCheckOutline />
@@ -88,7 +88,7 @@
             Share via NJump
           {/if}
         </Tooltip>
-        <Button class='btn-leather' size='xs' outline on:click={copyEventId}><ClipboardCleanOutline /></Button>
+        <Button class='btn-leather' size='xs' outline onclick={copyEventId}><ClipboardCleanOutline /></Button>
         <Tooltip class='tooltip-leather' type='auto' placement='top' on:show={() => eventIdCopied = false}>
           {#if eventIdCopied}
             <ClipboardCheckOutline />
@@ -96,7 +96,7 @@
             Copy event ID
           {/if}
         </Tooltip>
-        <Button class='btn-leather' size='xs' outline on:click={viewJson}><CodeOutline /></Button>
+        <Button class='btn-leather' size='xs' outline onclick={viewJson}><CodeOutline /></Button>
         <Tooltip class='tooltip-leather' type='auto' placement='top'>View JSON</Tooltip>
       </div>
     </div>

--- a/src/lib/components/ArticleHeader.svelte
+++ b/src/lib/components/ArticleHeader.svelte
@@ -9,37 +9,26 @@
 
   const { event } = $props<{ event: NDKEvent }>();
 
-  let title: string = $state('');
-  let author: string = $state('');
-  let version: string = $state('');
-  let href: string = $state('');
+  const relays = $derived.by(() => {
+    return $ndkInstance.activeUser?.relayUrls ?? standardRelays;
+  });
+
+  const href = $derived.by(() => {
+    const d = event.getMatchingTags('d')[0]?.[1];
+    if (d != null) {
+      return `publication?d=${d}`;
+    } else {
+      return `publication?id=${neventEncode(event, relays)}`;
+    }
+  });
+
+  let title: string = $derived(event.getMatchingTags('title')[0]?.[1]);
+  let author: string = $derived(event.getMatchingTags('author')[0]?.[1] ?? 'unknown');
+  let version: string = $derived(event.getMatchingTags('version')[0]?.[1] ?? '1');
+
   let eventIdCopied: boolean = $state(false);
   let jsonModalOpen: boolean = $state(false);
   let shareLinkCopied: boolean = $state(false);
-
-  $effect(() => {
-    try {
-      const relays = $ndkInstance.activeUser?.relayUrls ?? standardRelays;
-      title = event.getMatchingTags('title')[0]?.[1];
-      author = event.getMatchingTags('author')[0]?.[1];
-      if (author == null || author == '') {
-        author = 'unknown';
-      }
-      version = event.getMatchingTags('version')[0]?.[1];
-      if (version == null || version == '') {
-        version = '1';
-      }
-
-      const d = event.getMatchingTags('d')[0]?.[1];
-      if (d != null) {
-        href = `publication?d=${d}`;
-      } else {
-        href = `publication?id=${neventEncode(event, relays)}`;
-      }
-    } catch (e) {
-      console.warn(e);
-    }
-  });
 
   function copyEventId() {
     console.debug("copyEventID");

--- a/src/lib/components/ArticleHeader.svelte
+++ b/src/lib/components/ArticleHeader.svelte
@@ -20,17 +20,17 @@
   $effect(() => {
     try {
       const relays = $ndkInstance.activeUser?.relayUrls ?? standardRelays;
-      title = event.getMatchingTags('title')[0][1];
-      author = event.getMatchingTags('author')[0][1];
+      title = event.getMatchingTags('title')[0]?.[1];
+      author = event.getMatchingTags('author')[0]?.[1];
       if (author == null || author == '') {
         author = 'unknown';
       }
-      version = event.getMatchingTags('version')[0][1];
+      version = event.getMatchingTags('version')[0]?.[1];
       if (version == null || version == '') {
         version = '1';
       }
 
-      const d = event.getMatchingTags('d')[0][1];
+      const d = event.getMatchingTags('d')[0]?.[1];
       if (d != null) {
         href = `publication?d=${d}`;
       } else {

--- a/src/lib/components/Login.svelte
+++ b/src/lib/components/Login.svelte
@@ -3,7 +3,6 @@
   import { activePubkey, loginWithExtension, logout, ndkInstance, ndkSignedIn, persistLogin } from '$lib/ndk';
   import { Avatar, Button, Popover, Tooltip } from 'flowbite-svelte';
   import { ArrowRightToBracketOutline } from 'flowbite-svelte-icons';
-  import { onMount } from 'svelte';
 
   let profile = $state<NDKUserProfile | null>(null);
   let pfp = $derived(profile?.image);

--- a/src/lib/components/PublicationFeed.svelte
+++ b/src/lib/components/PublicationFeed.svelte
@@ -27,9 +27,9 @@
         until: before,
       },
       { 
-        groupable: true,
+        groupable: false,
         skipVerification: false,
-        skipValidation: false
+        skipValidation: false,
       },
       NDKRelaySet.fromRelayUrls(relays, $ndkInstance)
     );

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -1,7 +1,8 @@
 export const wikiKind = 30818;
 export const indexKind = 30040;
 export const zettelKinds = [ 30041 ];
-export const standardRelays = [ "wss://thecitadel.nostr1.com", "wss://relay.noswhere.com" ];
+export const standardRelays = [ 'wss://thecitadel.nostr1.com', 'wss://relay.noswhere.com' ];
+export const bootstrapRelays = [ 'wss://purplepag.es', 'wss://relay.noswhere.com' ];
 
 export enum FeedType {
   StandardRelays = 'standard',

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -4,8 +4,9 @@ export const zettelKinds = [ 30041 ];
 export const standardRelays = [ "wss://thecitadel.nostr1.com", "wss://relay.noswhere.com" ];
 
 export enum FeedType {
-  StandardRelays,
-  UserRelays,
+  StandardRelays = 'standard',
+  UserRelays = 'user',
 }
 
 export const loginStorageKey = 'alexandria/login/pubkey';
+export const feedTypeStorageKey = 'alexandria/feed/type';

--- a/src/lib/ndk.ts
+++ b/src/lib/ndk.ts
@@ -107,6 +107,9 @@ export function initNdk(): NDK {
       ? Array.from(startingInboxes.values())
       : standardRelays,
   });
+
+  // TODO: Should we prompt the user to confirm authentication?
+  ndk.relayAuthDefaultPolicy = NDKRelayAuthPolicies.signIn({ ndk });
   ndk.connect().then(() => console.debug("ndk connected"));
   return ndk;
 }
@@ -191,14 +194,14 @@ async function getUserPreferredRelays(
     relayList.tags.forEach(tag => {
       switch (tag[0]) {
         case 'r':
-          inboxRelays.add(new NDKRelay(tag[1]));
+          inboxRelays.add(new NDKRelay(tag[1], NDKRelayAuthPolicies.signIn({ ndk }), ndk));
           break;
         case 'w':
-          outboxRelays.add(new NDKRelay(tag[1]));
+          outboxRelays.add(new NDKRelay(tag[1], NDKRelayAuthPolicies.signIn({ ndk }), ndk));
           break;
         default:
-          inboxRelays.add(new NDKRelay(tag[1]));
-          outboxRelays.add(new NDKRelay(tag[1]));
+          inboxRelays.add(new NDKRelay(tag[1], NDKRelayAuthPolicies.signIn({ ndk }), ndk));
+          outboxRelays.add(new NDKRelay(tag[1], NDKRelayAuthPolicies.signIn({ ndk }), ndk));
           break;
       }
     });

--- a/src/lib/ndk.ts
+++ b/src/lib/ndk.ts
@@ -90,14 +90,22 @@ export function clearPersistedRelays(user: NDKUser): void {
 }
 
 /**
- * Initializes an instance of NDK, and connects it to the standard relays.
+ * Initializes an instance of NDK, and connects it to the logged-in user's preferred relay set
+ * (if available), or to Alexandria's standard relay set.
  * @returns The initialized NDK instance.
  */
 export function initNdk(): NDK {
+  const startingPubkey = getPersistedLogin();
+  const [startingInboxes, _] = startingPubkey != null
+    ? getPersistedRelays(new NDKUser({ pubkey: startingPubkey }))
+    : [null, null];
+
   const ndk = new NDK({
     autoConnectUserRelays: true,
     enableOutboxModel: true,
-    explicitRelayUrls: standardRelays,
+    explicitRelayUrls: startingInboxes != null
+      ? Array.from(startingInboxes.values()).map(relay => relay.url)
+      : standardRelays,
   });
   ndk.connect().then(() => console.debug("ndk connected"));
   return ndk;

--- a/src/lib/ndk.ts
+++ b/src/lib/ndk.ts
@@ -148,8 +148,9 @@ export async function loginWithExtension(pubkey?: string): Promise<NDKUser | nul
     const signer = new NDKNip07Signer();
     const signerUser = await signer.user();
 
+    // TODO: Handle changing pubkeys.
     if (pubkey && signerUser.pubkey !== pubkey) {
-      throw new Error(`The NIP-07 signer is not using the given pubkey: ${signerUser.pubkey}`);
+      console.debug('Switching pubkeys from last login.');
     }
 
     activePubkey.set(signerUser.pubkey);

--- a/src/lib/ndk.ts
+++ b/src/lib/ndk.ts
@@ -146,8 +146,8 @@ export async function loginWithExtension(pubkey?: string): Promise<NDKUser | nul
     ndk.signer = signer;
     ndk.activeUser = user;
 
-    ndkSignedIn.set(true);
     ndkInstance.set(ndk);
+    ndkSignedIn.set(true);
 
     return user;
   } catch (e) {

--- a/src/lib/ndk.ts
+++ b/src/lib/ndk.ts
@@ -73,11 +73,11 @@ function persistRelays(user: NDKUser, inboxes: Set<NDKRelay>, outboxes: Set<NDKR
  * @returns A tuple of relay sets of the form `[inboxRelays, outboxRelays]`.  Either set may be
  * empty if no relay lists were stored for the user.
  */
-function getPersistedRelays(user: NDKUser): [Set<NDKRelay>, Set<NDKRelay>] {
-  const inboxes = new Set<NDKRelay>(
+function getPersistedRelays(user: NDKUser): [Set<string>, Set<string>] {
+  const inboxes = new Set<string>(
     JSON.parse(localStorage.getItem(getRelayStorageKey(user, 'inbox')) ?? '[]')
   );
-  const outboxes = new Set<NDKRelay>(
+  const outboxes = new Set<string>(
     JSON.parse(localStorage.getItem(getRelayStorageKey(user, 'outbox')) ?? '[]')
   );
 
@@ -104,7 +104,7 @@ export function initNdk(): NDK {
     autoConnectUserRelays: true,
     enableOutboxModel: true,
     explicitRelayUrls: startingInboxes != null
-      ? Array.from(startingInboxes.values()).map(relay => relay.url)
+      ? Array.from(startingInboxes.values())
       : standardRelays,
   });
   ndk.connect().then(() => console.debug("ndk connected"));

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -4,3 +4,5 @@ import { FeedType } from "./consts";
 export let idList = writable<string[]>([]);
 
 export let alexandriaKinds = readable<number[]>([30040, 30041]);
+
+export let feedType = writable<FeedType>(FeedType.StandardRelays);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -4,5 +4,3 @@ import { FeedType } from "./consts";
 export let idList = writable<string[]>([]);
 
 export let alexandriaKinds = readable<number[]>([30040, 30041]);
-
-export let feedType = writable<FeedType>(FeedType.Relays);

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,10 +1,17 @@
+import { feedTypeStorageKey } from '$lib/consts';
+import { FeedType } from '$lib/consts';
 import { getPersistedLogin, initNdk, loginWithExtension, ndkInstance } from '$lib/ndk';
 import Pharos, { pharosInstance } from '$lib/parser';
+import { feedType } from '$lib/stores';
 import type { LayoutLoad } from './$types';
 
 export const ssr = false;
 
 export const load: LayoutLoad = () => {
+  const initialFeedType = localStorage.getItem(feedTypeStorageKey) as FeedType
+    ?? FeedType.StandardRelays;
+  feedType.set(initialFeedType);
+
   const ndk = initNdk();
   ndkInstance.set(ndk);
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -14,6 +14,8 @@ export const load: LayoutLoad = () => {
     // local storage.  If SSR is ever enabled, move this code block to run client-side.
     const pubkey = getPersistedLogin();
     if (pubkey) {
+      // Michael J - 27 Jan 2025 - We don't await this call; it will run in the background and
+      // update Svelte stores to propagate data.
       loginWithExtension(pubkey);
     }
   } catch (e) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,13 +1,18 @@
 <script lang='ts'>
-  import { FeedType, standardRelays } from '$lib/consts';
+  import { FeedType, feedTypeStorageKey, standardRelays } from '$lib/consts';
   import { Button, Dropdown, Radio } from 'flowbite-svelte';
   import { ChevronDownOutline } from 'flowbite-svelte-icons';
-  import { inboxRelays, ndkInstance, ndkSignedIn } from '$lib/ndk';
+  import { inboxRelays, ndkSignedIn } from '$lib/ndk';
   import PublicationFeed from '$lib/components/PublicationFeed.svelte';
 
-  let feedType: FeedType = $state(FeedType.StandardRelays);
+  let feedType: FeedType = $state(
+    localStorage.getItem(feedTypeStorageKey) as FeedType ?? FeedType.StandardRelays
+  );
 
-  // TODO: Remove feed type switching.  We will use relays only for now.
+  $effect(() => {
+    localStorage.setItem(feedTypeStorageKey, feedType);
+  });
+
   const getFeedTypeFriendlyName = (feedType: FeedType): string => {
     switch (feedType) {
     case FeedType.StandardRelays:

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,13 +4,10 @@
   import { ChevronDownOutline } from 'flowbite-svelte-icons';
   import { inboxRelays, ndkSignedIn } from '$lib/ndk';
   import PublicationFeed from '$lib/components/PublicationFeed.svelte';
-
-  let feedType: FeedType = $state(
-    localStorage.getItem(feedTypeStorageKey) as FeedType ?? FeedType.StandardRelays
-  );
+  import { feedType } from '$lib/stores';
 
   $effect(() => {
-    localStorage.setItem(feedTypeStorageKey, feedType);
+    localStorage.setItem(feedTypeStorageKey, $feedType);
   });
 
   const getFeedTypeFriendlyName = (feedType: FeedType): string => {
@@ -31,20 +28,20 @@
   {:else}
     <div class='leather w-full flex justify-end'>
       <Button>
-        {`Showing articles from: ${getFeedTypeFriendlyName(feedType)}`}<ChevronDownOutline class='w-6 h-6' />
+        {`Showing articles from: ${getFeedTypeFriendlyName($feedType)}`}<ChevronDownOutline class='w-6 h-6' />
       </Button>
       <Dropdown class='w-fit p-2 space-y-2 text-sm'>
         <li>
-          <Radio name='relays' bind:group={feedType} value={FeedType.StandardRelays}>Alexandria's Relays</Radio>
+          <Radio name='relays' bind:group={$feedType} value={FeedType.StandardRelays}>Alexandria's Relays</Radio>
         </li>
         <li>
-          <Radio name='follows' bind:group={feedType} value={FeedType.UserRelays}>Your Relays</Radio>
+          <Radio name='follows' bind:group={$feedType} value={FeedType.UserRelays}>Your Relays</Radio>
         </li>
       </Dropdown>
     </div>
-    {#if feedType === FeedType.StandardRelays}
+    {#if $feedType === FeedType.StandardRelays}
       <PublicationFeed relays={standardRelays} />
-    {:else if feedType === FeedType.UserRelays}
+    {:else if $feedType === FeedType.UserRelays}
       <PublicationFeed relays={$inboxRelays} />
     {/if}
   {/if}


### PR DESCRIPTION
The branch name is a bit of a misnomer, at this point.  This PR encompasses a series of bugfixes to improve stability, especially on Alexandria's main feed, and to improve the user sign-in experience.

## Changelog

- Improved handling of user-specified relay lists.
- Save home feed type to local storage so it persists across sessions.
- Upgraded the NDK version to fix a bug in which NDK was sending `REQ` messages with no filter.
- Fixed some errors that broke the pubkey switching workflow.
- Defined bootstrap relays to use when searching for a user profile on login.
- Set a default relay auth policy.
- Did some minor code cleanup and migrated more components to idiomatic Svelte 5 patterns.